### PR TITLE
(WIP) update to Dockerfile, fails on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-apache
+FROM php:8.1-apache
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \


### PR DESCRIPTION
Currently fails with:
```ruby
 => [ 7/20] RUN locale-gen                                                                                                                                             1.8s
 => [ 8/20] RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -                                                                                 1.0s
 => [ 9/20] RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list                                             0.5s
 => [10/20] RUN apt-get update                                                                                                                                         1.7s
 => ERROR [11/20] RUN apt-get install -y     msodbcsql17     mssql-tools                                                                                               1.0s
------
 > [11/20] RUN apt-get install -y     msodbcsql17     mssql-tools:
#16 0.235 Reading package lists...
#16 0.752 Building dependency tree...
#16 0.884 Reading state information...
#16 0.944 Some packages could not be installed. This may mean that you have
#16 0.944 requested an impossible situation or if you are using the unstable
#16 0.944 distribution that some required packages have not yet been created
#16 0.944 or been moved out of Incoming.
#16 0.944 The following information may help to resolve the situation:
#16 0.944 
#16 0.944 The following packages have unmet dependencies:
#16 1.012  libodbc1 : PreDepends: multiarch-support but it is not installable
#16 1.012  odbcinst1debian2 : PreDepends: multiarch-support but it is not installable
#16 1.028 E: Unable to correct problems, you have held broken packages.
------
executor failed running [/bin/sh -c apt-get install -y     msodbcsql17     mssql-tools]: exit code: 100
```

